### PR TITLE
new model architecture and baseline model weights

### DIFF
--- a/model_weights.txt
+++ b/model_weights.txt
@@ -1,0 +1,7 @@
+baseline_model1
+https://drive.google.com/file/d/1sgxcW-dCx7w06zFWDDoRJzl6q3dfhsf5/view?usp=drive_link
+
+baseline_model2
+https://drive.google.com/file/d/1j5O00NkbG_U8bG_MTODuHPXKVapZcz7q/view?usp=drive_link
+
+

--- a/newmodel.py
+++ b/newmodel.py
@@ -1,0 +1,151 @@
+import torch
+import torch.nn as nn
+
+class UNetDown(nn.Module):
+    def __init__(self, in_channels, out_channels, normalize=True, dropout=0.0, pooling=False):
+        super().__init__()
+
+        strides = 2
+        if pooling:
+            strides = 1
+            
+        layers = [nn.Conv2d(in_channels, out_channels, 3, stride=strides, padding=1, bias=False)]
+
+        if normalize:
+            layers.append(nn.InstanceNorm2d(out_channels)),
+
+        layers.append(nn.LeakyReLU(0.2))
+
+        if dropout:
+            layers.append(nn.Dropout(dropout))
+
+        if pooling:
+            layers.append(nn.MaxPool2d(2))
+
+        self.down = nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.down(x)
+        return x
+
+class UNetUp(nn.Module):
+    def __init__(self, in_channels, out_channels, dropout=0.0):
+        super().__init__()
+
+        layers = [
+            nn.ConvTranspose2d(in_channels, out_channels,4,2,1,bias=False),
+            nn.InstanceNorm2d(out_channels),
+            nn.LeakyReLU()
+        ]
+
+        if dropout:
+            layers.append(nn.Dropout(dropout))
+
+        self.up = nn.Sequential(*layers)
+
+    def forward(self,x,skip):
+        x = self.up(x)
+        x = torch.cat((x,skip),1)
+        return x
+
+
+class GeneratorUNet(nn.Module):
+    def __init__(self, in_channels=3, out_channels=3):
+        super().__init__()
+
+        self.down1 = UNetDown(in_channels, 32, normalize=False, pooling=False)
+        self.down2 = UNetDown(32,64)                 
+        self.down3 = UNetDown(64,128)               
+        self.down4 = UNetDown(128,256) 
+        self.down5 = UNetDown(256,256)      
+        self.down6 = UNetDown(256,256)             
+        self.down7 = UNetDown(256,256)              
+        self.down8 = UNetDown(256,256,normalize=False)
+
+        self.up1 = UNetUp(256,256,dropout=0.5)
+        self.up2 = UNetUp(512,256,dropout=0.5)
+        self.up3 = UNetUp(512,256,dropout=0.5)
+        self.up4 = UNetUp(512,256)
+        self.up5 = UNetUp(512,128)
+        self.up6 = UNetUp(256,64)
+        self.up7 = UNetUp(128,32)
+        self.up8 = nn.Sequential(
+            nn.ConvTranspose2d(64,3,4,stride=2,padding=1),
+            nn.Tanh()
+        )
+
+    def forward(self, x):
+        d1 = self.down1(x)
+        d2 = self.down2(d1)
+        d3 = self.down3(d2)
+        d4 = self.down4(d3)
+        d5 = self.down5(d4)
+        d6 = self.down6(d5)
+        d7 = self.down7(d6)
+        d8 = self.down8(d7)
+
+        u1 = self.up1(d8,d7)
+        u2 = self.up2(u1,d6)
+        u3 = self.up3(u2,d5)
+        u4 = self.up4(u3,d4)
+        u5 = self.up5(u4,d3)
+        u6 = self.up6(u5,d2)
+        u7 = self.up7(u6,d1)
+        u8 = self.up8(u7)
+
+        return u8
+
+class depthwise_separable_conv(nn.Module):
+    def __init__(self, nin, nout, kernel_size=3, strides=1, kernels_per_layer=1):
+      super(depthwise_separable_conv, self).__init__()
+      self.depthwise = nn.Conv2d(nin, nin * kernels_per_layer, kernel_size=kernel_size, stride=strides, padding=1, groups=nin)
+      self.pointwise = nn.Conv2d(nin * kernels_per_layer, nout, kernel_size=1)
+
+    def forward(self, x):
+      out = self.depthwise(x)
+      out = self.pointwise(out)
+      return out
+
+class Dis_block(nn.Module):
+    def __init__(self, in_channels, out_channels, normalize=True, downsampling=True):
+        super().__init__()
+
+        strides = 1
+        if downsampling:
+            strides = 2
+        
+        layers = [depthwise_separable_conv(in_channels, out_channels, 3, strides=strides)]
+        if normalize:
+            layers.append(nn.InstanceNorm2d(out_channels))
+        layers.append(nn.LeakyReLU(0.2))
+    
+        self.block = nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.block(x)
+        return x
+
+class Discriminator(nn.Module):
+    def __init__(self, in_channels=3):
+        super().__init__()
+
+        self.stage_1 = Dis_block(in_channels*2,64,normalize=False)#128
+        self.stage_2 = Dis_block(64,128)#64
+        self.stage_3 = Dis_block(128, 256)#32
+        self.stage_4 = Dis_block(256,256, downsampling=False)#16
+        self.patch = nn.Conv2d(256,1,3,padding=1) # 32x32 패치 생성
+
+    def forward(self,a,b):
+        x = torch.cat((a,b),1)
+        x = self.stage_1(x)
+        x = self.stage_2(x)
+        x = self.stage_3(x)
+        x = self.stage_4(x)
+        x = self.patch(x)
+        x = torch.sigmoid(x)
+        return x
+
+def initialize_weights(model):
+    class_name = model.__class__.__name__
+    if class_name.find('Conv') != -1:
+        nn.init.normal_(model.weight.data, 0.0, 0.02)

--- a/newtrain.py
+++ b/newtrain.py
@@ -1,0 +1,122 @@
+from torchvision.datasets import ImageFolder
+import torchvision.transforms as T
+from torch.utils.data.dataloader import DataLoader
+import wandb
+import torch
+import torch.nn as nn
+from torch import optim
+#from torch.optim.lr_scheduler import StepLR
+import argparse
+#import time
+#custom library
+import model
+import utils
+
+def train():
+    wandb.login()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--location', type=str, help="data location", default='./data')
+    parser.add_argument('--lr', type=float, help="learning rate", default=0.0001)
+    parser.add_argument('--batch_size', type=int, default=32)
+    parser.add_argument('--epoch', type=int, default=100)
+    parser.add_argument('--num_workers', type=int, default=8)
+    parser.add_argument('--beta1', type=float, default=0.5)
+    parser.add_argument('--beta2', type=float, default=0.999)
+    args = parser.parse_args()
+
+    wandb.init(
+        project="face2comic",
+        name=f"pix2pix-model-fix",
+        config={
+            "location":args.location,
+            "lr":args.lr,
+            "batch_size":args.batch_size,
+            "num_workers":args.num_workers,
+            "beta":(args.beta1, args.beta2),
+            "epoch":args.epoch,
+        }
+    )
+
+    config = wandb.config
+    utils.all_seed(42)
+    device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+
+    data = utils.CustomDataset(config.location)
+
+    data_loader = DataLoader(data,
+                            batch_size=config.batch_size,
+                            shuffle=True,
+                            num_workers=config.num_workers,
+                            pin_memory=True)
+
+    model_gen = model.GeneratorUNet()
+    model_dis = model.Discriminator()
+    model_gen.apply(model.initialize_weights)
+    model_dis.apply(model.initialize_weights)
+
+    criterion_gen = nn.BCELoss()
+    criterion_dis = nn.L1Loss()
+
+    lambda_pixel = 100
+
+    patch = (1, 32, 32)
+    optimizer_gen = optim.Adam(model_gen.parameters(), lr=config.lr, betas=config.beta)
+    optimizer_dis = optim.Adam(model_dis.parameters(), lr=config.lr, betas=config.beta)
+    #scheduler_gen = StepLR(optimizer_gen, step_size=20, gamma=0.1)
+    #scheduler_dis = StepLR(optimizer_dis, step_size=20, gamma=0.1)
+
+    model_gen.train()
+    model_dis.train()
+    model_gen, model_dis = model_gen.to(device), model_dis.to(device)
+
+    for epoch in range(config.epoch):
+        #start = time.time()
+        for face, comic in data_loader:
+            size = comic.size(0)
+            face, comic = face.to(device), comic.to(device)
+            face_label = torch.ones(size, *patch, requires_grad=False).to(device)
+            comic_label = torch.zeros(size, *patch, requires_grad=False).to(device)
+
+            model_gen.zero_grad()
+            
+            fake_comic = model_gen(face).to(device)
+            out_dis = model_dis(fake_comic, comic).to(device)
+
+            gen_loss = criterion_gen(out_dis, face_label)
+            pixel_loss = criterion_dis(fake_comic, comic)
+            g_loss = gen_loss + lambda_pixel * pixel_loss
+            g_loss.backward()
+            optimizer_gen.step()
+
+            model_dis.zero_grad()
+            
+            out_dis = model_dis(comic, face).to(device)
+            real_loss = criterion_gen(out_dis, face_label)
+
+            out_dis = model_dis(fake_comic.detach(), face).to(device)
+            fake_loss = criterion_gen(out_dis, comic_label)
+
+            d_loss = (real_loss + fake_loss) / 2.
+            d_loss.backward()
+            optimizer_dis.step()
+
+        #scheduler_dis.step()
+        #scheduler_gen.step()
+        wandb.log({'fake':wandb.Image(fake_comic[0].to('cpu')),
+                   'face':wandb.Image(face[0].to('cpu')),
+                   'comic':wandb.Image(comic[0].to('cpu'))})
+
+        torch.save({'gen':model_gen.state_dict(),
+                    'dis':model_dis.state_dict()},
+                    f'./model/{epoch}-0.001-bs-8.pt')
+        
+        #end = time.time()
+        #print('epoch %d time: '%epoch, end='')
+        #print(f"{end - start:.5f} sec")
+        
+        
+    wandb.finish()
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
모델 아키텍처 수정

- 판별자 모델에서 기존 Conv2d layer 대신 Saparable Conv2d layer 사용

- 생성자 모델에서 stride=2인 Conv2d layer 대신 maxpooling layer 사용할 수 있게 수정 + 생성자 모델 downsampling시에 Conv2d layer의 채널 크기를 기존 4에서 3으로 줄임

- 생성자 모델에서 Conv2d layer 채널 절반으로 줄임

- patchgan에서 patch size를 기존 16x16에서 32x32로 증가

- 판별자의 얕은 층에서 필터 수 증가


baseline model weights

- model_weights.txt파일로 baseline model 가중치 공유